### PR TITLE
Create blank.go

### DIFF
--- a/server/db/dynamodb/blank.go
+++ b/server/db/dynamodb/blank.go
@@ -1,0 +1,7 @@
+// +build !dynamodb
+
+// This file is needed for conditional compilation. It's used when
+// the build tag 'dynamodb' is not defined. Otherwise the adapter.go
+// is compiled.
+
+package dynamodb


### PR DESCRIPTION
This file is needed for conditional compilation. It's used when
the build tag 'dynamodb' is not defined. Otherwise the adapter.go
 is compiled.